### PR TITLE
Fix typo in registration label string

### DIFF
--- a/shared/features/auth/impl/src/commonMain/kotlin/ru/aleshin/studyassistant/auth/impl/presentation/theme/tokens/AuthStrings.kt
+++ b/shared/features/auth/impl/src/commonMain/kotlin/ru/aleshin/studyassistant/auth/impl/presentation/theme/tokens/AuthStrings.kt
@@ -124,7 +124,7 @@ internal data class AuthStrings(
             alreadyHavePasswordLabelSecond = "Войдите",
             registerDesc = "Регистрация",
             registerHeadline = "Давайте\nначнём вместе!",
-            registerLabel = "Зарегестрироваться",
+            registerLabel = "Зарегистрироваться",
             forgotDesc = "Восстановление пароля",
             forgotHeadline = "Давайте\nвосстановим\nваш пароль",
             sendEmailLabel = "Отправить письмо",


### PR DESCRIPTION
Change registerLabel from 'Зарегестрироваться' to 'Зарегистрироваться'.
Second Pull